### PR TITLE
Add reverse transform unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+before_install:
+  - pip install pytest
+script:
+  - py.test units/ -v
+

--- a/units/conversions.py
+++ b/units/conversions.py
@@ -3931,7 +3931,7 @@ Conversions = {
         "CELSIUS": (), # Same
         "FAHRENHEIT": ((32, 1), (1.8, 1)),
         "RANKINE": (None,),  # Undefined
-        "KELVIN": ((273.15, 1), (0, 1)),
+        "KELVIN": ((273.15, 1), (1, 0)),
 
     },
     "FAHRENHEIT": {
@@ -3949,7 +3949,7 @@ Conversions = {
 
     },
     "KELVIN": {
-        "CELSIUS": ((-273.15, 1), (0, 1)),
+        "CELSIUS": ((-273.15, 1), (1, 0)),
         "FAHRENHEIT": (None,),  # Undefined
         "RANKINE": (None,),  # Undefined
         "KELVIN": (), # Same

--- a/units/test_reverse.py
+++ b/units/test_reverse.py
@@ -1,3 +1,4 @@
+import pytest
 from conversions import Conversions
 
 
@@ -11,6 +12,12 @@ def find_all_conversions():
                 keys.append((category, from_unit, to_unit))
     return keys
 
-for key in find_all_conversions():
-    category, from_unit, to_unit = key
-    assert from_unit in Conversions[category][to_unit]
+conversion_keys = find_all_conversions()
+
+
+class TestReverse(object):
+
+    @pytest.mark.parametrize('key', conversion_keys)
+    def test_reverse_transform_exists(self, key):
+        category, from_unit, to_unit = key
+        assert from_unit in Conversions[category][to_unit]

--- a/units/test_reverse.py
+++ b/units/test_reverse.py
@@ -13,11 +13,12 @@ def find_all_conversions():
     return keys
 
 conversion_keys = find_all_conversions()
+conversion_ids = ["-".join(x) for x in conversion_keys]
 
 
 class TestReverse(object):
 
-    @pytest.mark.parametrize('key', conversion_keys)
+    @pytest.mark.parametrize('key', conversion_keys, ids=conversion_ids)
     def test_reverse_transform_exists(self, key):
         category, from_unit, to_unit = key
         assert from_unit in Conversions[category][to_unit]

--- a/units/test_reverse.py
+++ b/units/test_reverse.py
@@ -14,20 +14,20 @@ def list_converted_units():
 
 
 def list_conversions():
-    """List all conversions as (category, from_unit, to_unit) tuples"""
+    """
+    List all non self-transform conversions as (category, from_unit, to_unit)
+    tuples
+    """
     keys = []
     for category, to_unit in list_converted_units():
         for from_unit in Conversions[category][to_unit].keys():
-            keys.append((category, to_unit, from_unit))
+            if to_unit != from_unit:
+                keys.append((category, to_unit, from_unit))
     return keys
 
 
 def get_reverse_transform(transform):
     """Compute reverse transform"""
-
-    # Handle self-transforms
-    if not transform:
-        return ()
 
     # Temporararily handle undefined transforms
     if not transform[0]:

--- a/units/test_reverse.py
+++ b/units/test_reverse.py
@@ -3,6 +3,7 @@ from conversions import Conversions
 
 
 def find_all_conversions():
+    """List all conversion keys as (category, from_unit, to_unit) tuples"""
     keys = []
     categories = Conversions.keys()
     for category in categories:
@@ -12,6 +13,23 @@ def find_all_conversions():
                 keys.append((category, from_unit, to_unit))
     return keys
 
+
+def get_reverse_transform(transform):
+    """Compute reverse transform"""
+
+    # Handle self-transforms
+    if not transform:
+        return ()
+
+    # Temporararily handle undefined transforms
+    if not transform[0]:
+        return (None, )
+
+    return (
+        (-transform[0][0], transform[0][1]),
+        (transform[1][0], -transform[1][1]))
+
+
 conversion_keys = find_all_conversions()
 conversion_ids = ["-".join(x) for x in conversion_keys]
 
@@ -19,6 +37,11 @@ conversion_ids = ["-".join(x) for x in conversion_keys]
 class TestReverse(object):
 
     @pytest.mark.parametrize('key', conversion_keys, ids=conversion_ids)
-    def test_reverse_transform_exists(self, key):
+    def test_reverse_transform(self, key):
         category, from_unit, to_unit = key
         assert from_unit in Conversions[category][to_unit]
+
+        forward_transform = Conversions[category][from_unit][to_unit]
+        reverse_transform = Conversions[category][to_unit][from_unit]
+
+        assert reverse_transform == get_reverse_transform(forward_transform)

--- a/units/test_reverse.py
+++ b/units/test_reverse.py
@@ -2,15 +2,23 @@ import pytest
 from conversions import Conversions
 
 
-def find_all_conversions():
-    """List all conversion keys as (category, from_unit, to_unit) tuples"""
+def list_converted_units():
+    """List all conversion keys as (category, from_unit) tuples"""
     keys = []
     categories = Conversions.keys()
     for category in categories:
         conversion_dict = Conversions[category]
         for to_unit in conversion_dict.keys():
-            for from_unit in conversion_dict[to_unit].keys():
-                keys.append((category, from_unit, to_unit))
+            keys.append((category, to_unit))
+    return keys
+
+
+def list_conversions():
+    """List all conversions as (category, from_unit, to_unit) tuples"""
+    keys = []
+    for category, to_unit in list_converted_units():
+        for from_unit in Conversions[category][to_unit].keys():
+            keys.append((category, to_unit, from_unit))
     return keys
 
 
@@ -30,7 +38,7 @@ def get_reverse_transform(transform):
         (transform[1][0], -transform[1][1]))
 
 
-conversion_keys = find_all_conversions()
+conversion_keys = list_conversions()
 conversion_ids = ["-".join(x) for x in conversion_keys]
 
 

--- a/units/test_reverse.py
+++ b/units/test_reverse.py
@@ -1,0 +1,16 @@
+from conversions import Conversions
+
+
+def find_all_conversions():
+    keys = []
+    categories = Conversions.keys()
+    for category in categories:
+        conversion_dict = Conversions[category]
+        for to_unit in conversion_dict.keys():
+            for from_unit in conversion_dict[to_unit].keys():
+                keys.append((category, from_unit, to_unit))
+    return keys
+
+for key in find_all_conversions():
+    category, from_unit, to_unit = key
+    assert from_unit in Conversions[category][to_unit]

--- a/units/test_reverse.py
+++ b/units/test_reverse.py
@@ -38,13 +38,20 @@ def get_reverse_transform(transform):
         (transform[1][0], -transform[1][1]))
 
 
-conversion_keys = list_conversions()
-conversion_ids = ["-".join(x) for x in conversion_keys]
+converted_units = list_converted_units()
+converted_units_ids = ["-".join(x) for x in converted_units]
+conversions = list_conversions()
+conversion_ids = ["-".join(x) for x in conversions]
 
 
 class TestReverse(object):
 
-    @pytest.mark.parametrize('key', conversion_keys, ids=conversion_ids)
+    @pytest.mark.parametrize('key', converted_units, ids=converted_units_ids)
+    def test_self_transform(self, key):
+        category, to_unit = key
+        assert Conversions[category][to_unit][to_unit] == ()
+
+    @pytest.mark.parametrize('key', conversions, ids=conversion_ids)
     def test_reverse_transform(self, key):
         category, from_unit, to_unit = key
         assert from_unit in Conversions[category][to_unit]


### PR DESCRIPTION
Should be testable using `pytest`

```
py.test test_reverse.py -v
```

At the moment only 4 transforms are failing (temperature). Either we need to have a special rule for `c==0` or we need to use `(0, -1)` for completeness.

The content of these tests will differ if the nature of the transformation tuple changes.
 